### PR TITLE
Fix Unicode and datetime.datetime serialization issues.

### DIFF
--- a/gitissius/database.py
+++ b/gitissius/database.py
@@ -4,9 +4,25 @@
 import os.path
 import json
 import pickle
+import datetime
 
 import common
 import properties
+
+
+
+class DateTimeJSONEncoder(json.JSONEncoder):
+    """
+    Custom JSON Encoder for dealing with datetime properties.
+
+    Originally from http://stackoverflow.com/questions/455580
+    """
+    def default(self, obj):
+        if isinstance(obj, datetime.datetime):
+            return obj.isoformat()
+        else:
+            return super(DateTimeJSONEncoder, self).default(obj)
+
 
 class DbObject(object):
     """
@@ -38,7 +54,7 @@ class DbObject(object):
         """
         dic = {}
         for prop in self._properties:
-            dic[prop.name] = prop.repr('value')
+            dic[prop.name] = prop.repr('value').encode('utf8')
 
         return dic
 
@@ -70,7 +86,7 @@ class DbObject(object):
             item_data = item.serialize()
             data[item_data['name']] = item_data['value']
 
-        return json.dumps(data, indent=indent)
+        return json.dumps(data, indent=indent, cls=DateTimeJSONEncoder)
 
     @property
     def properties(self):

--- a/gitissius/gitissius
+++ b/gitissius/gitissius
@@ -1,0 +1,1 @@
+gitissius.py

--- a/gitissius/gitissius.py
+++ b/gitissius/gitissius.py
@@ -15,6 +15,10 @@ import os.path
 import shutil
 import sys
 import string
+import locale
+import logging
+logging.basicConfig(format='%(levelname)s:%(funcName)s:%(message)s',
+        level=logging.INFO)
 
 import gitshelve
 import common
@@ -23,6 +27,8 @@ import properties
 import database
 
 VERSION = "0.1.6"
+
+locale.setlocale(locale.LC_ALL)
 
 def usage(available_commands):
     USAGE = "Gitissius v%s\n\n" % VERSION

--- a/gitissius/properties.py
+++ b/gitissius/properties.py
@@ -1,6 +1,7 @@
 import common
 import hashlib
 import readline
+import logging
 
 readline.parse_and_bind('tab: complete')
 
@@ -34,6 +35,7 @@ class DbProperty(object):
         return ' '.join(map(lambda x: x.capitalize(), self.name.split('_')))
 
     def repr(self, attr):
+        logging.debug("attr = %s (%s)", attr, type(attr))
         value = getattr(self, attr)
 
         if common.colorama:
@@ -110,7 +112,7 @@ class DbProperty(object):
         Return a python dictionary ready to be jsonized
         """
         return {'name': self.name,
-                'value': unicode(self.value)
+                'value': self.value
                 }
 
 class Option(DbProperty):


### PR DESCRIPTION
Fixes: bab09 (and fixes #6)

Also, formatting of Unicode variables was broken.
